### PR TITLE
feat(message): removed the consumer callback and updated event name for messages

### DIFF
--- a/lib/topic.js
+++ b/lib/topic.js
@@ -13,7 +13,6 @@ module.exports = TopicMQ;
  * @param {Object} options.queue_options Queue options
  * @param {Object} options.consumer_options Consume options
  * @param {String} options.topic Topic name
- * @param {Function} options.consumer Callback function which consumes the messages
  */
 function TopicMQ (options) {
   options = options || {};
@@ -22,12 +21,10 @@ function TopicMQ (options) {
   this.subscribe = options.subscribe === undefined ? true : options.subscribe;
   this.consumer_options = options.consumer_options || {};
   this.topic = options.topic;
-  this.consumer = options.consumer;
   this.username = options.username;
   this.password = options.password;
   this.host = options.host;
   this.port = options.port;
-  if (typeof this.consumer !== 'function') this.consumer = () => {};
 };
 
 // Inherit from EventEmitter
@@ -121,7 +118,7 @@ TopicMQ.prototype.configQueue = function (q, channel) {
   channel.bindQueue(q.queue, this.exchange, this.topic);
   if (this.subscribe) {
     channel.consume(q.queue, (msg) => {
-      this.emit('consume', msg, q, this.consumer_options);
+      this.emit('message', msg, q, this.consumer_options);
     }, this.consumer_options);
   }
 };


### PR DESCRIPTION
Now you need to register a callback on the `message` event to receive messages from RabbitMQ. Here is a sample of use:

```
const { TopicMQ } = require('@hitch/mq');

const EXCHANGE_NAME = 'some-name'
const TOPIC_NAME = 'topic-name';

exports = module.exports = {};

const mq = new TopicMQ({
  exchange: EXCHANGE_NAME,
  queue_options: { exclusive: true },
  consumer_options: { noAck: true },
  topic: TOPIC_NAME,
  subscribe: true,
  username: process.env.USERNAME,
  password: process.env.PASSWORD,
  host: process.env.HOST || 'localhost',
  port: process.env.PORT || 5672
});

mq.on('connect', () => {
  console.log('connected');
});

mq.on('message', msg => {
  console.log('>> consumeMessage');
  console.log(msg.content.toString());
});

mq.connect();
```